### PR TITLE
Al/tailwind node

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test": "node ./test/runTest.js",
+    "dev": "webpack --watch",
     "webpack": "webpack"
   },
   "devDependencies": {

--- a/src/webview/Flow.jsx
+++ b/src/webview/Flow.jsx
@@ -73,9 +73,9 @@ const OverviewFlow = () => {
         nodeBorderRadius={2}
       />
       <Panel position="top-left">
-        <div className="border-1 border-gray-500">
+        <div className="text-black">
           <div className="flex justify-end place-items-end shadow-lg bg-slate-50 w-20 h-15">
-            <p className="pl-2 pr-2 py-2">Client: <span className="border-1 border-gray-500 bg-orange-300 text-transparent rounded-full">00</span></p>
+            <p className="pl-2 pr-2 py-2">Client: <span className="bg-orange-300 text-transparent rounded-full">00</span></p>
           </div>
           <div className="flex justify-end place-items-end shadow-lg bg-slate-50 w-20 h-15">
             <p className="pl-2 pr-2 pb-2">Server: <span className="bg-blue-300 text-transparent  rounded-full">00</span></p>

--- a/src/webview/flowBuilder.js
+++ b/src/webview/flowBuilder.js
@@ -21,13 +21,12 @@ class FlowBuilder {
     parsedData.forEach((item) => {
       const node = {
         id: (++this.id).toString(),
-        data: { // `py-2 px-9 shadow-lg rounded-md border-2 border-gray-500 flex justify-center place-items-center 
+        data: {
           label: (
             <div className="text-sm font-medium text-ellipsis overflow-hidden ..." key={this.id}>{item.fileName}</div>
           )
         },
         // type: item.depth === 0 ? 'input' : '',
-        // type: item.isClientComponent ? 'input' : 'output',
         type: 'default',
         position: { x: x += 40, y: y += 30 },
         style: {

--- a/src/webview/flowBuilder.js
+++ b/src/webview/flowBuilder.js
@@ -26,7 +26,7 @@ class FlowBuilder {
           label: (
             <div className={`-mx-2.5 -my-2.5 py-2 px-9 shadow-lg rounded-md border-2 border-gray-500 ${(item.isClientComponent) ? 'bg-orange-300' : 'bg-blue-300'}`}>
               <div className="flex justify-center place-items-center" key={this.id}>
-                <div className="text-base font-medium">{item.fileName}</div>
+                <div className="text-sm font-medium">{item.fileName}</div>
               </div>
             </div>
           )

--- a/src/webview/flowBuilder.js
+++ b/src/webview/flowBuilder.js
@@ -1,22 +1,20 @@
 import React from 'react';
-// import CustomNode from '../styles/CustomNode';
 // will create a build func and then call the helper funcs to return an object
 // make a new instance of this class in flow, call the build method, and pass this as state
-// const nodeTypes = {
-//   custom: CustomNode,
-// };
 
 class FlowBuilder {
   constructor(data) {
     this.parsedData = [data];
     this.id = 0;
+    this.x = 0;
+    this.y = 0;
     this.initialNodes = [];
     this.viewData;
     this.edgeId = 0;
     this.initialEdges = [];
   }
 
-  buildNodesArray(parsedData) {
+  buildNodesArray(parsedData, x = this.x, y = this.y) {
     if (!parsedData) return;
 
     parsedData.forEach((item) => {
@@ -34,7 +32,7 @@ class FlowBuilder {
         // type: item.depth === 0 ? 'input' : '',
         // type: item.isClientComponent ? 'input' : 'output',
         type: 'default',
-        position: { x: 0, y: 0 },
+        position: { x: x += 40, y: y += 30 },
         style: {
           border: 'none',
           borderRadius: "6px"
@@ -42,7 +40,7 @@ class FlowBuilder {
       };
       this.initialNodes.push(node);
       if (item.children) {
-        this.buildNodesArray(item.children);
+        this.buildNodesArray(item.children, this.x += 40, this.y += 30);
       }
     });
   };
@@ -98,7 +96,7 @@ class FlowBuilder {
       });
     }
     traverse(treeParsed);
-    // Update the vewData state
+    // Update the viewData state
     this.viewData = ([treeParsed]);
     console.log('viewData:', this.viewData);
     this.buildNodesArray(this.viewData);


### PR DESCRIPTION
## Overview

**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Fixed CSS in webview for each node to render the filename's length in accounted space. Added 'webpack --watch' flag in webpack.config.js to no longer require rebuilding. 