### PR TITLE
A single typo was causing the bug in ticket RL-27. Fixed the typo and…

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -419,7 +419,7 @@ export class Parser {
                 // Case for finding components passed in as props e.g. <Route component={App} />
             } else if (
                 astTokens[i].type.label === 'jsxName' &&
-                (astTokens[i].value === 'component' ||
+                (astTokens[i].value === 'Component' ||
                     astTokens[i].value === 'children') &&
                 importsObj[astTokens[i + 3].value]
             ) {


### PR DESCRIPTION
… works as intended

## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
There was a typo in the word component. Should've been a capitol C instead of lowercase. Works as intended after fixing the typo.

**Ticket Item**
Jira ticket: RL-27
