### PR TITLE
Removed unused handles from the root node and from leaf nodes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3459,13 +3459,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.45",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.45.tgz",
       "integrity": "sha512-TtAxCNrlrBp8GoeEp1npd5g+d/OejJHFxS3OWmrPBMFaVQMSN0OFySozJio5BHxTuTeug00AVXVAjfDSfk+lUg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -3485,7 +3485,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/vscode": {
       "version": "1.85.0",
@@ -4637,7 +4637,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/d3": {
       "version": "7.8.5",
@@ -8584,7 +8584,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/webview/flowBuilder.tsx
+++ b/src/webview/flowBuilder.tsx
@@ -32,7 +32,7 @@ class FlowBuilder {
       nodes.push({
         id: node.data.id,
         position: { x: node.x ? node.x : 0, y: node.y ? node.y : 0 },
-        type: 'default',
+        type: node.depth === 0 ? 'input' : !node.children ? 'output' : 'default',
         data: { label: node.data.name },
         style: {
           borderRadius: '6px',


### PR DESCRIPTION
## Overview

**Issue Type**

- [ ] Bug
- [x] Feature
- [ ] Tech Debt

**Description**
Created a ternary expression that conditionally assigns node 'type' based on it's place in the tree. The root node is rendered as 'input' by checking the depth of the tree. The leaf nodes are rendered as 'output' nodes by checking to see if given node has children. 

**Ticket Item**
RL - 45

**Previous behavior**
Originally nodes were all being rendered as 'default' nodes, which have both input and output edge handles.