### PR TITLE
Disabled draggable new edges

### DIFF
--- a/src/webview/Flow.tsx
+++ b/src/webview/Flow.tsx
@@ -9,9 +9,10 @@ import ReactFlow, {
   Node,
   Edge
 } from "reactflow";
-import "reactflow/dist/style.css";
 import FlowBuilder from "./flowBuilder";
 import { Tree } from "../types/tree";
+import "reactflow/dist/style.css";
+import "./style.css";
 
 
 

--- a/src/webview/style.css
+++ b/src/webview/style.css
@@ -5,6 +5,7 @@
 html,
 body,
 #root,
+
 .App {
   height: 100%;
 }
@@ -12,4 +13,9 @@ body,
 .App {
   font-family: sans-serif;
   text-align: center;
+}
+
+
+.react-flow__handle.connectionindicator {
+  pointer-events: none !important;
 }


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
Removed ability to drag new edges from any currently used edge handles by styling the component <react-flow__handle.connectionindicator> directly to not allow pointer events.

**Ticket Item**

RL - 46

**Steps to Validate Feature**

1. Hover over any edges handle.
2. Notice lack of pointer change to crosshair pointer.
3. Attempt to click and drag.
4. Nothing happenes.

**Previous behavior**
Hovering over edge handle would change pointer to crosshair then on click, hold, and drag and new edge would appear starting at edge handle and end at cursor. The new handle could not however be connected to anything as that event was also disabled.

**Expected behavior**
Now works as described above

**Additional context**
This change was made on the same branch as RL-45
