### PR TITLE
Fl/rl 42 43 44/memory leak cleanup

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,14 +12,13 @@ let panel: vscode.WebviewPanel | undefined = undefined
 function activate(context: vscode.ExtensionContext) {
 
 	// This is the column where Webview will be revealed to
-	const columnToShowIn : vscode.ViewColumn | undefined = vscode.window.activeTextEditor
+	let columnToShowIn : vscode.ViewColumn | undefined = vscode.window.activeTextEditor
         ? vscode.window.activeTextEditor.viewColumn
         : undefined;
 
 	
 	// Command that allows for User to select the root file of their React application.
 	const pickFile: vscode.Disposable = vscode.commands.registerCommand('myExtension.pickFile', async () => {
-
 
 		// Check if there is an existing webview panel, if so display it.
 		if(panel) {
@@ -52,6 +51,19 @@ function activate(context: vscode.ExtensionContext) {
 			panel.dispose()
 			panel = createPanel(context, data, columnToShowIn);
 		}
+
+		// Listens for when webview is closed and disposes of webview resources
+		panel.onDidDispose(
+			() => {
+				console.log("Before: ", panel)
+				panel.dispose()
+				panel = undefined;
+				columnToShowIn = undefined;
+				console.log("After: ", panel)
+			},
+			null,
+			context.subscriptions
+			);
 	});
 
 

--- a/src/panel.ts
+++ b/src/panel.ts
@@ -35,16 +35,6 @@ export function createPanel(context: vscode.ExtensionContext, data: Tree, column
     // render html of webview here
     panel.webview.html = createWebviewHTML(bundleURI, data);
 
-
-    // Listens for when webview is closed and disposes of webview resources
-    panel.onDidDispose(
-        () => {
-          panel = undefined;
-        },
-        null,
-        context.subscriptions
-      );
-
     
     // Sends data to Flow.tsx to be displayed after parsed data is received
     panel.webview.onDidReceiveMessage(


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
After you close the initial Webview, any subsequent attempt to open another Webview was not allowed.


**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**

1. `npm run webpack`
2. Click `F5` to open extension simulator.
3. Click `View Tree` in React Labyrinth extension and select root file.
4. Close Webview and click `View Tree` again and select another file to make sure it allows for another Webview now.

**Previous behavior**
Would not allow another Webview to be opened if initial Webview was disposed.

**Expected behavior**
Can now close initial Webview and as many webviews as you would like.

**Screenshots & Videos**

https://github.com/oslabs-beta/React-Labyrinth/assets/133042142/2b060d65-32f9-4efc-a0a1-7a06effb60b6


