### PR TITLE
Fixed bug for Show Panel command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -60,7 +60,18 @@ function activate(context: vscode.ExtensionContext) {
 
 	// Command to show panel if it is hidden
 	const showPanel: vscode.Disposable = vscode.commands.registerCommand('myExtension.showPanel', () => {
-		panel.reveal(columnToShowIn);
+		if (!panel) {
+
+			showNotification({message: 'Please select root file of app', timeout: 3000});
+			return;
+
+		} else {
+
+			panel.reveal(columnToShowIn);
+			return;
+			
+		}
+		
 	});
 
 	context.subscriptions.push(pickFile, showPanel);


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
`Show Panel` command was throwing a Vs Code error when it was ran before a root file was selected.


**Steps to Reproduce Bug / Validate Feature / Confirm Tech Debt Fix**

1. `npm install`
2. `npm run dev`
3. Click `F5` to run Vs Code extension simulator
4. `CMD` + `SHFT` + `P` and select `Show Panel` command.

**Previous behavior**
Would throw a Vs Code error.

**Expected behavior**
Shows message in bottom corner of Vs Code to prompt user to select root file.

**Screenshots & Videos**
If applicable, add screenshots and videos to help explain your issue type.
![Screenshot 2024-02-12 at 14 28 41](https://github.com/oslabs-beta/React-Labyrinth/assets/133042142/478cf6d0-4591-4977-8899-c0fc4debb493)


https://github.com/oslabs-beta/React-Labyrinth/assets/133042142/14aa0068-be16-4aa9-9e7f-1daa397bd346


