### PR TITLE
Bug with Updated README.md in VS Code Marketplace

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Client Components will be distinguished by an orange background, while Server Co
 
 ## Publications
 
-Check out our Medium articles: [Part 1](https://lnkd.in/eYawkr6H) and [Part 2](https://medium.com/@ashleyluu87/data-flow-from-vs-code-extension-webview-panel-react-components-2f94b881467e) for more information about React Labyrinth!
+Check out our Medium articles: [Part 1](https://medium.com/@franciscoglopez49/react-labyrinth-a-helping-hand-with-react-server-components-84406d2ebf2c) and [Part 2](https://medium.com/@ashleyluu87/data-flow-from-vs-code-extension-webview-panel-react-components-2f94b881467e) for more information about React Labyrinth!
 
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "react-labyrinth",
   "displayName": "React Labyrinth",
   "description": "React Component Type hierarchy tree visualization tool",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "icon": "./media/reactLabyrinthFinal.png",
   "publisher": "react-labyrinth",
   "preview": false,
@@ -80,7 +80,8 @@
     "prod": "webpack --mode production --config webpack.config.ts",
     "compile": "tsc -p ./",
     "coverage": "jest --coverage",
-    "deploy": "vsce publish"
+    "deploy": "vsce publish",
+    "package": "vsce package"
   },
   "devDependencies": {
     "@babel/preset-typescript": "^7.23.3",


### PR DESCRIPTION
## Overview

**Issue Type**

- [x] Bug
- [ ] Feature
- [ ] Tech Debt

**Description**
When trying to update the README.md to the VS Code marketplace, we get an error saying that our content is not allowed. After connecting with the VS Code marketplace team, they mentioned replacing any shortened URLs. I hope the replaced URL of our first medium article will solve this problem.

I upgraded version 1.0.1 to 1.0.2 to defer errors when it comes to existing versions of an extension in CI/CD pipelines.
